### PR TITLE
Sidebar task fetching

### DIFF
--- a/apps/frontend/app/api/tasks/route.ts
+++ b/apps/frontend/app/api/tasks/route.ts
@@ -1,13 +1,16 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
-import { db } from '@repo/db';
+import { auth } from "@/lib/auth";
+import { db } from "@repo/db";
+import { headers } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
 
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
   try {
-    const session = await auth();
-    
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const tasks = await db.task.findMany({
@@ -24,18 +27,14 @@ export async function GET(request: NextRequest) {
         createdAt: true,
         updatedAt: true,
       },
-      orderBy: [
-        { repoUrl: 'asc' },
-        { status: 'asc' },
-        { updatedAt: 'desc' },
-      ],
+      orderBy: [{ repoUrl: "asc" }, { status: "asc" }, { updatedAt: "desc" }],
     });
 
     return NextResponse.json({ tasks });
   } catch (error) {
-    console.error('Error fetching tasks:', error);
+    console.error("Error fetching tasks:", error);
     return NextResponse.json(
-      { error: 'Internal server error' },
+      { error: "Internal server error" },
       { status: 500 }
     );
   }

--- a/apps/frontend/components/sidebar/index.tsx
+++ b/apps/frontend/components/sidebar/index.tsx
@@ -1,24 +1,19 @@
 "use client";
 
 import {
-  Archive,
+  AlertTriangle,
   Brain,
-  Calendar,
   CheckCircle2,
   ChevronDown,
   CircleDashed,
+  Clock,
   Folder,
   GitBranch,
-  Home,
-  Inbox,
   Monitor,
-  Search,
-  Settings,
-  Play,
   Pause,
+  Play,
+  Settings,
   XCircle,
-  Clock,
-  AlertTriangle,
 } from "lucide-react";
 
 import {
@@ -31,16 +26,18 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { Button } from "../ui/button";
-import Link from "next/link";
+import { useTasks } from "@/hooks/use-tasks";
+import { Task } from "@repo/db";
 import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { Button } from "../ui/button";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "../ui/collapsible";
-import { useState, useEffect } from "react";
-import { usePathname } from "next/navigation";
 
 const buttons = [
   {
@@ -77,17 +74,6 @@ const statusConfig = {
   CANCELLED: { icon: AlertTriangle, className: "text-gray-500" },
 };
 
-interface Task {
-  id: string;
-  title: string | null;
-  description: string | null;
-  status: keyof typeof statusConfig;
-  repoUrl: string;
-  branch: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
 interface GroupedTasks {
   [repoUrl: string]: {
     repoName: string;
@@ -95,53 +81,44 @@ interface GroupedTasks {
   };
 }
 
-export function SidebarComponent() {
+interface SidebarComponentProps {
+  initialTasks: Task[];
+}
+
+export function SidebarComponent({ initialTasks }: SidebarComponentProps) {
   const pathname = usePathname();
   const isTaskPage = pathname.match(/^\/tasks\/[^/]+$/);
-  const [tasks, setTasks] = useState<Task[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
   const [activeView, setActiveView] = useState<"home" | "task">(
-    isTaskPage ? "task" : "home",
+    isTaskPage ? "task" : "home"
   );
 
-  useEffect(() => {
-    async function fetchTasks() {
-      try {
-        const response = await fetch('/api/tasks');
-        if (!response.ok) {
-          throw new Error('Failed to fetch tasks');
-        }
-        const data = await response.json();
-        setTasks(data.tasks || []);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch tasks');
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchTasks();
-  }, []);
+  const {
+    data: tasks = [],
+    isLoading: loading,
+    error,
+    refetch,
+  } = useTasks(initialTasks);
 
   // Group tasks by repository and sort within each group
-  const groupedTasks: GroupedTasks = tasks.reduce((groups, task) => {
-    const repoName = task.repoUrl.split('/').slice(-2).join('/'); // Extract owner/repo from URL
-    
-    if (!groups[task.repoUrl]) {
-      groups[task.repoUrl] = {
-        repoName,
-        tasks: [],
-      };
-    }
-    
-    groups[task.repoUrl].tasks.push(task);
-    return groups;
-  }, {} as GroupedTasks);
+  const groupedTasks: GroupedTasks = tasks.reduce(
+    (groups: GroupedTasks, task: Task) => {
+      const repoName = task.repoUrl.split("/").slice(-2).join("/"); // Extract owner/repo from URL
+
+      if (!groups[task.repoUrl]) {
+        groups[task.repoUrl] = {
+          repoName,
+          tasks: [],
+        };
+      }
+
+      groups[task.repoUrl]?.tasks.push(task);
+      return groups;
+    },
+    {} as GroupedTasks
+  );
 
   // Sort tasks within each group by status priority, then by updated date
-  Object.values(groupedTasks).forEach(group => {
+  Object.values(groupedTasks).forEach((group) => {
     group.tasks.sort((a, b) => {
       const statusDiff = statusOrder[a.status] - statusOrder[b.status];
       if (statusDiff !== 0) return statusDiff;
@@ -191,71 +168,77 @@ export function SidebarComponent() {
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
-          
+
           {loading && (
             <SidebarGroup>
               <SidebarGroupLabel>Loading tasks...</SidebarGroupLabel>
             </SidebarGroup>
           )}
-          
+
           {error && (
             <SidebarGroup>
               <SidebarGroupLabel className="text-red-500">
-                Error: {error}
+                Error: {error instanceof Error ? error.message : String(error)}
               </SidebarGroupLabel>
             </SidebarGroup>
           )}
-          
-          {!loading && !error && Object.entries(groupedTasks).map(([repoUrl, group]) => (
-            <Collapsible
-              key={repoUrl}
-              defaultOpen={true}
-              className="group/collapsible"
-            >
-              <SidebarGroup>
-                <SidebarGroupLabel asChild>
-                  <CollapsibleTrigger>
-                    <Folder className="mr-1.5 !size-3.5" />
-                    {group.repoName}
-                    <ChevronDown className="ml-auto -rotate-90 transition-transform group-data-[state=open]/collapsible:rotate-0" />
-                  </CollapsibleTrigger>
-                </SidebarGroupLabel>
-                <CollapsibleContent>
-                  <SidebarGroupContent>
-                    {group.tasks.map((task) => {
-                      const StatusIcon = statusConfig[task.status].icon;
-                      return (
-                        <SidebarMenuItem key={task.id}>
-                          <SidebarMenuButton
-                            className="flex h-auto flex-col items-start gap-0"
-                            asChild
-                          >
-                            <a href={`/tasks/${task.id}`}>
-                              <div className="flex w-full items-center gap-2">
-                                <StatusIcon 
-                                  className={`!size-3.5 ${statusConfig[task.status].className}`} 
-                                />
-                                <div className="line-clamp-1 flex-1">
-                                  {task.title || task.description || 'Untitled Task'}
+
+          {!loading &&
+            !error &&
+            Object.entries(groupedTasks).map(([repoUrl, group]) => (
+              <Collapsible
+                key={repoUrl}
+                defaultOpen={true}
+                className="group/collapsible"
+              >
+                <SidebarGroup>
+                  <SidebarGroupLabel asChild>
+                    <CollapsibleTrigger>
+                      <Folder className="mr-1.5 !size-3.5" />
+                      {group.repoName}
+                      <ChevronDown className="ml-auto -rotate-90 transition-transform group-data-[state=open]/collapsible:rotate-0" />
+                    </CollapsibleTrigger>
+                  </SidebarGroupLabel>
+                  <CollapsibleContent>
+                    <SidebarGroupContent>
+                      {group.tasks.map((task) => {
+                        const StatusIcon = statusConfig[task.status].icon;
+                        return (
+                          <SidebarMenuItem key={task.id}>
+                            <SidebarMenuButton
+                              className="flex h-auto flex-col items-start gap-0"
+                              asChild
+                            >
+                              <a href={`/tasks/${task.id}`}>
+                                <div className="flex w-full items-center gap-2">
+                                  <StatusIcon
+                                    className={`!size-3.5 ${statusConfig[task.status].className}`}
+                                  />
+                                  <div className="line-clamp-1 flex-1">
+                                    {task.title ||
+                                      task.description ||
+                                      "Untitled Task"}
+                                  </div>
                                 </div>
-                              </div>
-                              <div className="text-muted-foreground flex items-center gap-1 text-xs">
-                                <GitBranch className="size-3" /> {task.branch}
-                                <span className="capitalize text-xs">
-                                  {task.status.toLowerCase().replace('_', ' ')}
-                                </span>
-                              </div>
-                            </a>
-                          </SidebarMenuButton>
-                        </SidebarMenuItem>
-                      );
-                    })}
-                  </SidebarGroupContent>
-                </CollapsibleContent>
-              </SidebarGroup>
-            </Collapsible>
-          ))}
-          
+                                <div className="text-muted-foreground flex items-center gap-1 text-xs">
+                                  <GitBranch className="size-3" /> {task.branch}
+                                  <span className="capitalize text-xs">
+                                    {task.status
+                                      .toLowerCase()
+                                      .replace("_", " ")}
+                                  </span>
+                                </div>
+                              </a>
+                            </SidebarMenuButton>
+                          </SidebarMenuItem>
+                        );
+                      })}
+                    </SidebarGroupContent>
+                  </CollapsibleContent>
+                </SidebarGroup>
+              </Collapsible>
+            ))}
+
           {!loading && !error && Object.keys(groupedTasks).length === 0 && (
             <SidebarGroup>
               <SidebarGroupLabel className="text-muted-foreground">

--- a/apps/frontend/hooks/use-tasks.tsx
+++ b/apps/frontend/hooks/use-tasks.tsx
@@ -1,0 +1,15 @@
+import { Task } from "@repo/db";
+import { useQuery } from "@tanstack/react-query";
+
+export function useTasks(initialData?: Task[]) {
+  return useQuery({
+    queryKey: ["tasks"],
+    queryFn: async () => {
+      const res = await fetch("/api/tasks");
+      if (!res.ok) throw new Error("Failed to fetch tasks");
+      const data = await res.json();
+      return data.tasks || [];
+    },
+    initialData,
+  });
+}


### PR DESCRIPTION
- Added a new /api/tasks endpoint (apps/frontend/app/api/tasks/route.ts) that fetches tasks for the authenticated user from the database, returning id, title, description, status, repoUrl, branch, createdAt, updatedAt.
- Root layout (apps/frontend/app/layout.tsx) now fetches initial tasks server-side and passes them as initialTasks prop to SidebarComponent, using cookies for auth.
- SidebarComponent (apps/frontend/components/sidebar/index.tsx) refactored to:
  - Use useTasks hook for fetching and updating tasks.
  - Group tasks by repo, sort by status and updatedAt.
  - Show status icons, repo/branch, and handle loading/error/empty states.
- Added useTasks hook (apps/frontend/hooks/use-tasks.tsx) for fetching tasks with React Query, supporting initial data.
- Removed hardcoded task sections and sample data from SidebarComponent; now fully dynamic.