### PR TITLE
Refactor types package definitions

### DIFF
--- a/apps/frontend/components/chat/tools/run-terminal-cmd.tsx
+++ b/apps/frontend/components/chat/tools/run-terminal-cmd.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import type { Message, ToolStatusType } from "@repo/types";
+import type { Message, ToolExecutionStatus } from "@repo/types";
 import { CheckIcon, Loader, Terminal, X } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { CollapsibleTool } from "./collapsible-tool";
@@ -48,7 +48,7 @@ function TerminalOutput({ output, isRunning, error }: TerminalOutputProps) {
   );
 }
 
-function StatusBadge({ status }: { status: ToolStatusType }) {
+function StatusBadge({ status }: { status: ToolExecutionStatus }) {
   const config = {
     RUNNING: {
       icon: Loader,

--- a/apps/frontend/components/task/task-content.tsx
+++ b/apps/frontend/components/task/task-content.tsx
@@ -15,7 +15,7 @@ import type {
   StreamChunk,
   TextPart,
   ToolCallPart,
-  ToolStatusType,
+  ToolExecutionStatus,
 } from "@repo/types";
 import { useEffect, useState } from "react";
 import { StickToBottom } from "use-stick-to-bottom";
@@ -25,7 +25,7 @@ interface StreamingToolCall {
   id: string;
   name: string;
   args: Record<string, any>;
-  status: ToolStatusType;
+  status: ToolExecutionStatus;
   result?: string;
   error?: string;
 }

--- a/apps/frontend/lib/actions/create-task.ts
+++ b/apps/frontend/lib/actions/create-task.ts
@@ -1,8 +1,7 @@
 "use server";
 
 import { auth } from "@/lib/auth";
-import { prisma, Task } from "@repo/db";
-import { MessageRole } from "@repo/types";
+import { prisma, Task, MessageRole } from "@repo/db";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { after } from "next/server";

--- a/package-lock.json
+++ b/package-lock.json
@@ -15178,9 +15178,14 @@
     "packages/types": {
       "name": "@repo/types",
       "version": "0.0.0",
+      "dependencies": {
+        "@repo/db": "*",
+        "ai": "^4.0.37"
+      },
       "devDependencies": {
         "@repo/eslint-config": "^0.0.0",
         "@repo/typescript-config": "*",
+        "@types/node": "^22.0.0",
         "eslint": "^9.31.0",
         "prettier": "^3.6.2",
         "prettier-plugin-organize-imports": "^4.1.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,9 +12,14 @@
     "lint": "eslint 'src/**/*.ts'",
     "check-types": "tsc --noEmit"
   },
+  "dependencies": {
+    "@repo/db": "*",
+    "ai": "^4.0.37"
+  },
   "devDependencies": {
     "@repo/eslint-config": "^0.0.0",
     "@repo/typescript-config": "*",
+    "@types/node": "^22.0.0",
     "eslint": "^9.31.0",
     "prettier": "^3.6.2",
     "prettier-plugin-organize-imports": "^4.1.0",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -38,8 +38,10 @@ export interface MessageMetadata {
   tool?: {
     name: string;
     args: Record<string, any>;
-    status: ToolStatusType;
+    status: "RUNNING" | "COMPLETED" | "FAILED"; // Tool-specific status subset
     result?: any;
+    error?: string; // Error message if failed
+    changes?: any; // For tools that make changes (like file edits)
   };
 
   // For structured assistant messages - required for chronological tool call ordering
@@ -168,25 +170,15 @@ export interface StreamChunk {
   };
 }
 
-// === Database Enums ===
+// === Re-export database types for convenience ===
+// Note: Import these from @repo/db instead of redefining
+export type { 
+  MessageRole, 
+  TaskStatus as ToolStatusType  // Alias for backwards compatibility
+} from "@repo/db";
 
-export const MessageRole = {
-  USER: "USER",
-  ASSISTANT: "ASSISTANT",
-  TOOL: "TOOL",
-  SYSTEM: "SYSTEM",
-} as const;
-
-export type MessageRoleType = (typeof MessageRole)[keyof typeof MessageRole];
-
-// Tool status that aligns with database TaskStatus
-export const ToolStatus = {
-  RUNNING: "RUNNING",
-  COMPLETED: "COMPLETED",
-  FAILED: "FAILED",
-} as const;
-
-export type ToolStatusType = (typeof ToolStatus)[keyof typeof ToolStatus];
+// Tool execution status - subset of TaskStatus that's relevant for UI components
+export type ToolExecutionStatus = "RUNNING" | "COMPLETED" | "FAILED";
 
 // === LLM Integration Types ===
 


### PR DESCRIPTION
Refactor `@repo/types` to remove redundant definitions by leveraging Prisma-generated types.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-fcb3bcfe-2cf7-4433-a288-bb87a8174295) · [Cursor](https://cursor.com/background-agent?bcId=bc-fcb3bcfe-2cf7-4433-a288-bb87a8174295)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)