### PR TITLE
Add conversation header in chat view

### DIFF
--- a/apps/frontend/app/tasks/[taskId]/page.tsx
+++ b/apps/frontend/app/tasks/[taskId]/page.tsx
@@ -49,7 +49,7 @@ export default async function TaskPage({
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <TaskPageLayout initialLayout={initialLayout} />
+      <TaskPageLayout initialLayout={initialLayout} task={task} />
     </HydrationBoundary>
   );
 }

--- a/apps/frontend/components/task/conversation-header.tsx
+++ b/apps/frontend/components/task/conversation-header.tsx
@@ -1,0 +1,23 @@
+import type { Task } from "@/lib/db-operations/get-task";
+
+export function ConversationHeader({
+  task,
+  added,
+  removed,
+}: {
+  task: Task;
+  added: number;
+  removed: number;
+}) {
+  return (
+    <div className="text-xs text-muted-foreground border rounded-md p-2 mb-4 w-full">
+      <div className="font-semibold">
+        {task.repoUrl} ({task.branch})
+      </div>
+      <div>Started: {new Date(task.createdAt).toLocaleString()}</div>
+      <div>
+        Changes: +{added} -{removed}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/task/task-layout.tsx
+++ b/apps/frontend/components/task/task-layout.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useIsAtTop } from "@/hooks/use-is-at-top";
 import { saveLayoutCookie } from "@/lib/actions/save-sidebar-cookie";
+import type { Task } from "@/lib/db-operations/get-task";
 import { cn } from "@/lib/utils";
 import { AppWindowMac } from "lucide-react";
 import { useCallback, useEffect, useRef } from "react";
@@ -27,8 +28,10 @@ import { TaskPageContent } from "./task-content";
 
 export function TaskPageLayout({
   initialLayout,
+  task,
 }: {
   initialLayout?: number[];
+  task: Task;
 }) {
   const rightPanelRef = useRef<ImperativePanelHandle>(null);
   const resizablePanelGroupRef = useRef<ImperativePanelGroupHandle>(null);
@@ -132,7 +135,7 @@ export function TaskPageLayout({
               </TooltipContent>
             </Tooltip>
           </div>
-          <TaskPageContent isAtTop={isAtTop} />
+          <TaskPageContent isAtTop={isAtTop} task={task} />
         </StickToBottom>
       </ResizablePanel>
       <ResizableHandle />


### PR DESCRIPTION
## Summary
- show repository info and line change stats above chat messages
- wire task info through layout and content components

## Testing
- `npm run lint` *(fails: eslint config not found)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687dcc76526c832cad67516f7f3d5610