### PR TITLE
feat(frontend): add /random demo page

### DIFF
--- a/apps/frontend/app/(home)/random/page.tsx
+++ b/apps/frontend/app/(home)/random/page.tsx
@@ -1,0 +1,16 @@
+import { LuckyRandomPanel } from "@/components/random/lucky-random-panel";
+import { HomeLayoutWrapper } from "@/components/layout/home-layout";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Random | Shadow",
+  description: "A small demo page with a random number and phrase.",
+};
+
+export default function RandomPage() {
+  return (
+    <HomeLayoutWrapper>
+      <LuckyRandomPanel />
+    </HomeLayoutWrapper>
+  );
+}

--- a/apps/frontend/components/random/lucky-random-panel.tsx
+++ b/apps/frontend/components/random/lucky-random-panel.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Dices } from "lucide-react";
+import { useState } from "react";
+
+const PHRASES = [
+  "Small steps beat big plans.",
+  "Refactor when it hurts, not when it's trendy.",
+  "The best code is code you can delete later.",
+  "Read the error message twice.",
+  "One failing test is a compass.",
+  "Naming is cheaper than comments.",
+  "Ship it, then make it true.",
+];
+
+export function LuckyRandomPanel() {
+  const [roll, setRoll] = useState<{
+    n: number;
+    phrase: string;
+  } | null>(null);
+
+  const handleRoll = () => {
+    setRoll({
+      n: Math.floor(Math.random() * 100) + 1,
+      phrase: PHRASES[Math.floor(Math.random() * PHRASES.length)]!,
+    });
+  };
+
+  return (
+    <div className="relative z-10 flex min-h-0 flex-1 flex-col items-center justify-center gap-8 p-6">
+      <Card className="border-border/80 w-full max-w-md shadow-md">
+        <CardHeader>
+          <CardTitle className="font-departureMono text-lg tracking-tight">
+            Random corner
+          </CardTitle>
+          <CardDescription>
+            A throwaway page: roll a number and a line of pseudo-wisdom.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-6">
+          <div className="space-y-1">
+            <p className="text-muted-foreground text-xs uppercase tracking-wide">
+              Lucky number
+            </p>
+            <p className="font-departureMono text-4xl tabular-nums">
+              {roll ? roll.n : "—"}
+            </p>
+          </div>
+          <blockquote className="text-muted-foreground border-border border-l-2 pl-4 text-sm leading-relaxed">
+            {roll ? roll.phrase : "Press the button to conjure something."}
+          </blockquote>
+          <Button
+            type="button"
+            onClick={handleRoll}
+            className="w-full sm:w-auto"
+          >
+            <Dices className="size-4" />
+            Roll again
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a new route at **`/random`** (inside the `(home)` group so it uses the same sidebar + `HomeLayoutWrapper` shell as the main app).
- Renders a small **Random corner** card with a 1–100 roll and a random phrase, using existing `Button` / `Card` UI.

## How to try it
Open `/random` while running the frontend dev server.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be34fa3f-5350-4d18-8b8d-4a3fdae8ff48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be34fa3f-5350-4d18-8b8d-4a3fdae8ff48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

