### PR TITLE
feat: make Shadow Wiki mini model customizable in settings

### DIFF
--- a/apps/frontend/app/api/user-settings/route.ts
+++ b/apps/frontend/app/api/user-settings/route.ts
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { autoPullRequest, enableShadowWiki, memoriesEnabled, selectedModels, enableIndexing, rules } =
+    const { autoPullRequest, enableShadowWiki, memoriesEnabled, selectedModels, miniModel, enableIndexing, rules } =
       body;
 
     // Validate autoPullRequest if provided
@@ -81,6 +81,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Validate miniModel if provided
+    if (miniModel !== undefined && miniModel !== null && typeof miniModel !== "string") {
+      return NextResponse.json(
+        { error: "miniModel must be a string or null" },
+        { status: 400 }
+      );
+    }
+
     // Validate rules if provided
     if (rules !== undefined && rules !== null && typeof rules !== "string") {
       return NextResponse.json(
@@ -106,6 +114,7 @@ export async function POST(request: NextRequest) {
       enableShadowWiki?: boolean;
       memoriesEnabled?: boolean;
       selectedModels?: string[];
+      miniModel?: string | null;
       enableIndexing?: boolean;
       rules?: string;
     } = {};
@@ -117,6 +126,8 @@ export async function POST(request: NextRequest) {
       updateData.memoriesEnabled = memoriesEnabled;
     if (selectedModels !== undefined)
       updateData.selectedModels = selectedModels;
+    if (miniModel !== undefined)
+      updateData.miniModel = miniModel || null;
     if (enableIndexing !== undefined)
       updateData.enableIndexing = enableIndexing;
     if (rules !== undefined)

--- a/apps/frontend/components/auth/settings-modal/model-settings.tsx
+++ b/apps/frontend/components/auth/settings-modal/model-settings.tsx
@@ -9,6 +9,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   useApiKeys,
   useSaveApiKey,
   useClearApiKey,
@@ -31,6 +38,8 @@ import { useDebounceCallbackWithCancel } from "@/lib/debounce";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   ApiKeyProvider,
+  ModelType,
+  ModelInfos,
   getProviderDefaultModel,
   getModelProvider,
 } from "@repo/types";
@@ -38,6 +47,31 @@ import { useModal } from "@/components/layout/modal-context";
 import { getModelSelectorCookie } from "@/lib/actions/model-selector-cookie";
 import { useSetSelectedModel } from "@/hooks/chat/use-selected-model";
 import { getValidationResult } from "@/lib/types/validation";
+import {
+  useUserSettings,
+  useUpdateUserSettings,
+} from "@/hooks/use-user-settings";
+import { getAllPossibleModelsInfo } from "@/lib/actions/api-keys";
+
+// Mini models available per provider for Shadow Wiki processing
+const MINI_MODELS: Record<string, { id: ModelType; name: string }[]> = {
+  openai: [
+    { id: "gpt-4o-mini" as ModelType, name: "GPT-4o Mini" },
+    { id: "gpt-4.1-mini" as ModelType, name: "GPT-4.1 Mini" },
+    { id: "gpt-5-mini-2025-08-07" as ModelType, name: "GPT-5 Mini" },
+  ],
+  anthropic: [
+    { id: "claude-3-5-haiku-20241022" as ModelType, name: "Claude 3.5 Haiku" },
+  ],
+  openrouter: [
+    { id: "x-ai/grok-3" as ModelType, name: "Grok 3" },
+    {
+      id: "deepseek/deepseek-chat-v3-0324" as ModelType,
+      name: "DeepSeek Chat V3",
+    },
+    { id: "qwen/qwen3-coder" as ModelType, name: "Qwen3 Coder" },
+  ],
+};
 
 export function ModelSettings() {
   const { data: apiKeys, isLoading: isLoadingApiKeys } = useApiKeys();
@@ -49,6 +83,13 @@ export function ModelSettings() {
   const queryClient = useQueryClient();
   const { openProviderConfig } = useModal();
   const setSelectedModelMutation = useSetSelectedModel();
+  const { data: userSettings } = useUserSettings();
+  const updateUserSettings = useUpdateUserSettings();
+
+  // Compute available mini models based on which API keys the user has
+  const availableMiniModels = Object.entries(MINI_MODELS)
+    .filter(([provider]) => apiKeys?.[provider as keyof typeof apiKeys])
+    .flatMap(([, models]) => models);
 
   const [openaiInput, setOpenaiInput] = useState(apiKeys?.openai ?? "");
   const [anthropicInput, setAnthropicInput] = useState(
@@ -435,6 +476,41 @@ export function ModelSettings() {
           </div>
         );
       })}
+
+      {/* Mini Model Selection */}
+      {availableMiniModels.length > 0 && (
+        <div className="flex w-full flex-col gap-2 border-t pt-4">
+          <Label className="font-normal">
+            Shadow Wiki Mini Model
+          </Label>
+          <p className="text-muted-foreground text-xs">
+            Used for file analysis and code summarization in Shadow Wiki. A
+            smaller, faster model keeps costs low.
+          </p>
+          <Select
+            value={userSettings?.miniModel ?? "auto"}
+            onValueChange={(value) => {
+              updateUserSettings.mutate({
+                miniModel: value === "auto" ? null : value,
+              });
+            }}
+          >
+            <SelectTrigger data-size="sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="auto" data-size="sm">
+                Auto (provider default)
+              </SelectItem>
+              {availableMiniModels.map((model) => (
+                <SelectItem key={model.id} value={model.id} data-size="sm">
+                  {model.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
 
       <div className="text-muted-foreground flex w-full flex-col gap-1 border-t pt-4 text-xs">
         <span>Shadow is BYOK; you must provide an API key to use models.</span>

--- a/apps/frontend/hooks/use-user-settings.tsx
+++ b/apps/frontend/hooks/use-user-settings.tsx
@@ -14,6 +14,7 @@ interface UserSettings {
   enableShadowWiki: boolean;
   memoriesEnabled: boolean;
   selectedModels: string[];
+  miniModel?: string | null;
   enableIndexing: boolean;
   rules?: string | null;
   createdAt: Date;
@@ -25,6 +26,7 @@ type UpdateUserSettingsParams = {
   memoriesEnabled?: boolean;
   enableShadowWiki?: boolean;
   selectedModels?: string[];
+  miniModel?: string | null;
   enableIndexing?: boolean;
   rules?: string | null;
 };
@@ -56,6 +58,7 @@ async function updateUserSettingsAPI(settings: {
   memoriesEnabled?: boolean;
   enableShadowWiki?: boolean;
   selectedModels?: string[];
+  miniModel?: string | null;
   enableIndexing?: boolean;
   rules?: string | null;
 }): Promise<UserSettings> {

--- a/apps/frontend/lib/db-operations/user-settings.ts
+++ b/apps/frontend/lib/db-operations/user-settings.ts
@@ -7,6 +7,7 @@ export interface UserSettings {
   enableShadowWiki: boolean;
   memoriesEnabled: boolean;
   selectedModels: string[];
+  miniModel?: string | null;
   enableIndexing: boolean;
   rules?: string | null;
   createdAt: Date;
@@ -30,6 +31,7 @@ export async function createUserSettings(
     enableShadowWiki?: boolean;
     memoriesEnabled?: boolean;
     selectedModels?: string[];
+    miniModel?: string;
     enableIndexing?: boolean;
     rules?: string;
   }
@@ -41,6 +43,7 @@ export async function createUserSettings(
       enableShadowWiki: settings.enableShadowWiki ?? true,
       memoriesEnabled: settings.memoriesEnabled ?? true,
       selectedModels: settings.selectedModels ?? [],
+      miniModel: settings.miniModel,
       enableIndexing: settings.enableIndexing ?? false,
       rules: settings.rules,
     },
@@ -56,6 +59,7 @@ export async function updateUserSettings(
     enableShadowWiki?: boolean;
     memoriesEnabled?: boolean;
     selectedModels?: string[];
+    miniModel?: string | null;
     enableIndexing?: boolean;
     rules?: string;
   }
@@ -66,6 +70,7 @@ export async function updateUserSettings(
       enableShadowWiki?: boolean;
       memoriesEnabled?: boolean;
       selectedModels?: string[];
+      miniModel?: string | null;
       enableIndexing?: boolean;
       rules?: string;
     } = {};
@@ -78,6 +83,8 @@ export async function updateUserSettings(
       updateData.memoriesEnabled = settings.memoriesEnabled;
     if (settings.selectedModels !== undefined)
       updateData.selectedModels = settings.selectedModels;
+    if (settings.miniModel !== undefined)
+      updateData.miniModel = settings.miniModel;
     if (settings.enableIndexing !== undefined)
       updateData.enableIndexing = settings.enableIndexing;
     if (settings.rules !== undefined)
@@ -90,6 +97,7 @@ export async function updateUserSettings(
       enableShadowWiki?: boolean;
       memoriesEnabled?: boolean;
       selectedModels?: string[];
+      miniModel?: string;
       enableIndexing?: boolean;
       rules?: string;
     } = {
@@ -116,6 +124,8 @@ export async function updateUserSettings(
       settings.selectedModels.length > 0
     )
       createData.selectedModels = settings.selectedModels;
+    if (settings.miniModel !== undefined && settings.miniModel !== null)
+      createData.miniModel = settings.miniModel;
     if (
       settings.enableIndexing !== undefined &&
       settings.enableIndexing !== false

--- a/apps/server/src/indexing/shadowwiki/core.ts
+++ b/apps/server/src/indexing/shadowwiki/core.ts
@@ -1308,7 +1308,8 @@ export async function runShadowWiki(
     miniModel = options.modelMini;
   } else {
     mainModel = context.getModelForOperation("pr-gen");
-    miniModel = getHardcodedMiniModel(context.getProvider());
+    // Use user's mini model preference if provided, otherwise fall back to hardcoded default
+    miniModel = options.modelMini || getHardcodedMiniModel(context.getProvider());
   }
 
   if (!context.validateAccess()) {

--- a/apps/server/src/indexing/shadowwiki/routes.ts
+++ b/apps/server/src/indexing/shadowwiki/routes.ts
@@ -85,6 +85,18 @@ shadowWikiRouter.post("/generate/:taskId", async (req, res, next) => {
 
     console.log(`[SHADOW-WIKI] Analyzing workspace directly: ${workspaceDir}`);
 
+    // Resolve mini model: request body > user settings > hardcoded fallback
+    let resolvedMiniModel = modelMini as ModelType | undefined;
+    if (!resolvedMiniModel) {
+      const userSettings = await db.userSettings.findUnique({
+        where: { userId: task.userId },
+        select: { miniModel: true },
+      });
+      if (userSettings?.miniModel) {
+        resolvedMiniModel = userSettings.miniModel as ModelType;
+      }
+    }
+
     // Run Shadow Wiki analysis directly on workspace
     const result = await runShadowWiki(
       taskId,
@@ -95,7 +107,7 @@ shadowWikiRouter.post("/generate/:taskId", async (req, res, next) => {
       {
         concurrency: 12,
         model: model as ModelType,
-        modelMini: modelMini as ModelType,
+        modelMini: resolvedMiniModel,
         recursionLimit: 1,
       }
     );

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -284,6 +284,7 @@ model UserSettings {
   enableShadowWiki Boolean  @default(true)
   enableIndexing   Boolean  @default(false)
   selectedModels   String[] @default([])
+  miniModel        String?
   rules            String?
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt


### PR DESCRIPTION
Fixes #117

## Problem
Shadow Wiki uses hardcoded mini models per provider (`getHardcodedMiniModel()` in `core.ts`):
- Anthropic → Claude 3.5 Haiku
- OpenAI → GPT-4o Mini
- OpenRouter → Grok 3

Users have no way to change this — the issue asks for it to be customizable in the Models tab.

## Fix
Added a `miniModel` field to `UserSettings` and a selector in the Models settings tab. The resolution order is:

1. **Request body** `modelMini` (API-level override, existing behavior)
2. **User settings** `miniModel` (new — read from DB in routes.ts)
3. **Hardcoded fallback** (existing `getHardcodedMiniModel()`)

The selector shows mini-appropriate models filtered by which API keys the user has configured. "Auto (provider default)" resets to the hardcoded fallback.

### Files changed
| File | What |
|---|---|
| `schema.prisma` | Add `miniModel String?` to UserSettings |
| `user-settings.ts` (db-ops) | Add `miniModel` to interfaces + upsert logic |
| `use-user-settings.tsx` | Add `miniModel` to hook types |
| `route.ts` (API) | Validate + pass `miniModel` in POST |
| `model-settings.tsx` | Mini model selector UI |
| `routes.ts` (server) | Read user preference from DB before generation |
| `core.ts` (server) | Accept standalone `modelMini` without requiring `model` too |

## What it doesn't change
- Default behavior unchanged (hardcoded fallback still works when no preference set)
- No changes to the main model selector or chat model selection
- No changes to Shadow Wiki analysis logic itself
- Existing API callers that pass `modelMini` in request body still work